### PR TITLE
:construction: séparation des données entre lille et bordeaux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,4 +193,4 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 DS_Store
-datas/
+data/


### PR DESCRIPTION
## Summary by Sourcery

Separate data for Lille and Bordeaux and adjust .gitignore to ignore the new data files.

New Features:
- Separate datasets for Lille and Bordeaux to isolate location-specific data

Enhancements:
- Update .gitignore to exclude environment-specific data files